### PR TITLE
Fix bug to handle duplicate subnet across different vpc networks

### DIFF
--- a/plugins/modules/gcp_compute_subnetwork.py
+++ b/plugins/modules/gcp_compute_subnetwork.py
@@ -317,6 +317,7 @@ from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import (
 )
 import json
 import time
+import ipaddress
 
 ################################################################################
 # Main
@@ -353,7 +354,10 @@ def main():
 
     if fetch:
         if state == 'present':
-            if is_different(module, fetch):
+            if module.params['network']['selfLink'] != fetch['network']: # found difference on same subnet within the same VPC network
+                module.fail_json(msg="Subnet already exists in a different VPC network: %s, please change the name or region" % fetch['network'])
+                changed = False
+            elif is_different(module, fetch):
                 update(module, self_link(module), kind, fetch)
                 fetch = fetch_resource(module, self_link(module), kind)
                 changed = True


### PR DESCRIPTION
GCP doesn't allow to create any subnet with the same name in the same region if already exists in any other VPC network, and the original module doesn't throw error. This PR suggests adding a condition check and error out for this scenario. 